### PR TITLE
修复集合方法extend使用错误的提示信息

### DIFF
--- a/src/common/pl/plpgsql/src/gram.y
+++ b/src/common/pl/plpgsql/src/gram.y
@@ -4047,7 +4047,7 @@ stmt_execsql			: K_ALTER
             }
         | T_ARRAY_EXTEND
             {
-                check_table_index(yylval.wdatum.datum, "trim");
+                check_table_index(yylval.wdatum.datum, "extend");
                 int dno = yylval.wdatum.dno;
                 StringInfoData sqlBuf;
 


### PR DESCRIPTION
```sql
 DECLARE
    -- Associative array indexed by string:
    TYPE population IS TABLE OF NUMERIC  -- Associative array type
    INDEX BY VARCHAR(64);            --  indexed by string

    city_population population;
begin

    city_population('Smallville')  := 2000;
    
    city_population.extend; -- EXTEND is not support the Associative array

end;
/

```
ERROR:  index by varchar type don't support **trim** function at or near "city_population"

这个提示信息是有问题的，用例使用的是extend方法，但是执行提示是使用了trim方法。